### PR TITLE
fix: custom lerna commit message to prevent infinite ci hook

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent"
+  "version": "independent",
+  "npmClient": "yarn",
+  "command": {
+    "publish": {
+      "message": "publish npm packages by lerna [ci skip]"
+    }
+  }
 }


### PR DESCRIPTION
- lerna use custom commit message (`[ci skip]`) to prevent inifinite ci hook